### PR TITLE
Feature: IPAddress to BigInteger method

### DIFF
--- a/IPAddress/src/inet/ipaddr/IPAddress.java
+++ b/IPAddress/src/inet/ipaddr/IPAddress.java
@@ -18,6 +18,7 @@
 
 package inet.ipaddr;
 
+import java.math.BigInteger;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -1008,7 +1009,24 @@ public abstract class IPAddress extends Address {
 		Integer newPrefix = getEquivalentPrefix();
 		return newPrefix == null ? null : applyPrefixLength(newPrefix);
 	}
-	
+
+	/**
+	 * Returns the equivalent BigInteger address.
+	 *
+	 * Examples:
+	 * 1.2.3.4 returns 16909060
+	 * 1:2:3:4:5:6:7:8 returns 5192455318486707404433266433261576
+	 *
+	 * @return
+	 */
+	public BigInteger toBigInteger() {
+		BigInteger value = BigInteger.valueOf(0);
+		for (IPAddressSegment seg : this.getSegments()) {
+			value = value.shiftLeft(this.getBitsPerSegment()).add(BigInteger.valueOf(seg.getLowerValue()));
+		}
+		return value;
+	}
+
 	/**
 	 * Constructs an equivalent address with the smallest CIDR prefix possible (largest network),
 	 * such that the address represents the exact same range of addresses.

--- a/IPAddress/src/inet/ipaddr/test/IPAddressTest.java
+++ b/IPAddress/src/inet/ipaddr/test/IPAddressTest.java
@@ -18,6 +18,7 @@
 
 package inet.ipaddr.test;
 
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -1705,6 +1706,15 @@ public class IPAddressTest extends TestBase {
 		incrementTestCount();
 	}
 
+	void testBigIntegerConversion(String str, BigInteger expectedInteger) {
+		IPAddressString addrStr = createAddress(str);
+		IPAddress addr = addrStr.getAddress();
+		if(!addr.toBigInteger().equals(expectedInteger)) {
+			addFailure(new Failure("expected " + expectedInteger + " got " + addr.toBigInteger()));
+		}
+		incrementTestCount();
+	}
+
 	//returns true if this testing class allows inet_aton, leading zeros extending to extra digits, empty addresses, and basically allows everything
 	boolean isLenient() {
 		return false;
@@ -3346,7 +3356,10 @@ public class IPAddressTest extends TestBase {
 		ipv6test(1,"::0:a:b:c:d:e:f"); // syntactically correct, but bad form (::0:... could be combined)
 		ipv6test(1,"a:b:c:d:e:f:0::");
 		ipv6test(0,"':10.0.0.1");
-		
+
+		testBigIntegerConversion("1.2.3.4", BigInteger.valueOf(16909060));
+		testBigIntegerConversion("1:2:3:4:5:6:7:8", new BigInteger("5192455318486707404433266433261576"));
+
 		testSQLMatching();
 	}
 }


### PR DESCRIPTION
Hi Sean

Just added a method to IPAddress for converting it to a BigInteger, which is useful for comparing ranges of addresses numerically.