### PR TITLE
Add a ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        java: [ 8, 11, 17, 21 ]
+      fail-fast: false
+      max-parallel: 16
+    name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up JDK
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - name: Build with Maven
+        run: mvn -B clean install


### PR DESCRIPTION
This PR adds a minimal GitHub Actions workflow that runs the Maven build across multiple JDK versions (8, 11, 17, 21) on Ubuntu. It will help you don't need to clone and build every external submission locally just to check for regressions. And contributors can confirm that their changes build correctly across JDK versions before submitting a PR.

It’s lightweight and shouldn’t cause any trouble. And It's non-intrusive and can be removed or modified easily as needed.

Please feel free to close this PR if it doesn’t align with your preferences for the project. Just wanted to offer this as a small convenience for you and future contributors alike. Thanks!